### PR TITLE
Add option to specify service port name and update docs

### DIFF
--- a/docs/pages/configuration/service.mdx
+++ b/docs/pages/configuration/service.mdx
@@ -35,7 +35,7 @@ The `port` option is mandatory and expect an integer with a port number. The ser
 The `containerPort` option is optional and tells the service to forward the traffic from the service port (defined in `port`) to a different `containerPort` of a pod.
 
 ### `name`
-The `name` option is optional and allows you to customise the name of the port. By default ports will be named "port-0", "port-1" etc.
+The `name` option is optional and allows you to customize the name of the port. By default ports will be named "port-0", "port-1" etc.
 
 #### Default for `containerPort`
 ```yaml

--- a/docs/pages/configuration/service.mdx
+++ b/docs/pages/configuration/service.mdx
@@ -34,14 +34,20 @@ The `port` option is mandatory and expect an integer with a port number. The ser
 ### `containerPort`
 The `containerPort` option is optional and tells the service to forward the traffic from the service port (defined in `port`) to a different `containerPort` of a pod.
 
-### `name`
-The `name` option is optional and allows you to customize the name of the port. By default ports will be named "port-0", "port-1" etc.
-
 #### Default for `containerPort`
 ```yaml
 containerPort: [same as `port` option]
 ```
 
+### `name`
+The `name` option is optional and allows you to customize the name of the port. 
+
+#### Default for `name`
+By default the port name will be "port-0", "port-1" etc.
+
+```yaml
+name: port-0
+```
 
 ### `protocol`
 The `protocol` option is optional and expects a string that defines the network protocol for this service port.

--- a/docs/pages/configuration/service.mdx
+++ b/docs/pages/configuration/service.mdx
@@ -34,6 +34,9 @@ The `port` option is mandatory and expect an integer with a port number. The ser
 ### `containerPort`
 The `containerPort` option is optional and tells the service to forward the traffic from the service port (defined in `port`) to a different `containerPort` of a pod.
 
+### `name`
+The `name` option is optional and allows you to customise the name of the port. By default ports will be named "port-0", "port-1" etc.
+
 #### Default for `containerPort`
 ```yaml
 containerPort: [same as `port` option]

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -26,7 +26,11 @@ spec:
     {{- end }}
   ports:
     {{- range $portMapIndex, $portMap := $.Values.service.ports }}
+    {{- if $portMap.name }}
+    - name: {{ $portMap.name }}
+    {{- else }}
     - name: "port-{{ $portMapIndex }}"
+    {{- end }}
       port: {{ $portMap.port }}
       {{- if $portMap.containerPort }}
       targetPort: {{ $portMap.containerPort }}


### PR DESCRIPTION
I have added the option to specify service port names. This is useful when you are integrating with systems that rely on port naming conventions like Istio. Istio expects service port names begin with "http" for example.