### PR TITLE
Add missing quotes for hosts

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -101,7 +101,7 @@ spec:
   tls:
   - hosts:
     {{- range $ingressRuleIndex, $ingressRule := $.Values.ingress.rules }}
-    - {{ $ingressRule.host }}
+    - {{ $ingressRule.host | quote }}
     {{- end }}
     secretName: {{ $tlsSecretName | quote }}
   {{- end }}


### PR DESCRIPTION
Since hosts can have special characters "*.my-domain.tld", it must be quoted, otherwise getting an error:
```
[fatal]  Error deploying api: Unable to deploy helm chart: YAML parse error on component-chart/templates/ingress.yaml: error converting YAML to JSON: yaml: line 33: did not find expected alphabetic or numeric character
```

fixes #32 